### PR TITLE
Subtract received token from current tx spending

### DIFF
--- a/contracts/spend-limit/.gitignore
+++ b/contracts/spend-limit/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea

--- a/contracts/spend-limit/Cargo.toml
+++ b/contracts/spend-limit/Cargo.toml
@@ -14,7 +14,8 @@ cw-storage-plus = "1.1.0"
 cw2 = "1.1.2"
 itertools = "0.12.1"
 osmosis-authenticators = "0.22.0-alpha.19"
-osmosis-std = {git = " https://github.com/osmosis-labs/osmosis-rust", branch = "main"}
+# osmosis-std = {git = " https://github.com/osmosis-labs/osmosis-rust", branch = "main"}
+osmosis-std = {path = "../../../osmosis-rust/packages/osmosis-std"}
 rstest = "0.18.2"
 schemars = "0.8.12"
 serde = "1.0.180"
@@ -30,6 +31,6 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 
 [dev-dependencies]
 mock-cosmwasm-contract = "0.1.2"
-osmosis-test-tube = {git = " https://github.com/osmosis-labs/test-tube", branch = "main"}
-# osmosis-test-tube = {path = "../../../test-tube/packages/osmosis-test-tube"}
+# osmosis-test-tube = {git = " https://github.com/osmosis-labs/test-tube", branch = "main"}
+osmosis-test-tube = {path = "../../../test-tube/packages/osmosis-test-tube"}
 rstest = "0.18.2"

--- a/contracts/spend-limit/Cargo.toml
+++ b/contracts/spend-limit/Cargo.toml
@@ -14,7 +14,7 @@ cw-storage-plus = "1.1.0"
 cw2 = "1.1.2"
 itertools = "0.12.1"
 osmosis-authenticators = "0.22.0-alpha.19"
-osmosis-std = {git = " https://github.com/osmosis-labs/osmosis-rust", branch = "authenticator"}
+osmosis-std = {git = " https://github.com/osmosis-labs/osmosis-rust", branch = "main"}
 rstest = "0.18.2"
 schemars = "0.8.12"
 serde = "1.0.180"
@@ -30,6 +30,6 @@ optimize = """docker run --rm -v "$(pwd)":/code \
 
 [dev-dependencies]
 mock-cosmwasm-contract = "0.1.2"
-osmosis-test-tube = {git = " https://github.com/osmosis-labs/test-tube", branch = "authenticator"}
+osmosis-test-tube = {git = " https://github.com/osmosis-labs/test-tube", branch = "main"}
 # osmosis-test-tube = {path = "../../../test-tube/packages/osmosis-test-tube"}
 rstest = "0.18.2"

--- a/contracts/spend-limit/src/authenticator/common.rs
+++ b/contracts/spend-limit/src/authenticator/common.rs
@@ -1,6 +1,6 @@
 use std::cmp::max;
 
-use cosmwasm_std::{Addr, Coin, DepsMut, Fraction, StdError, Timestamp, Uint128};
+use cosmwasm_std::{Addr, Coin, DepsMut, StdError, Timestamp, Uint128};
 
 use crate::{
     period::Period,
@@ -58,9 +58,7 @@ pub fn update_and_check_spend_limit(
             continue;
         };
 
-        value_spent = value_spent
-            .checked_sub(received_coin_value)
-            .map_err(StdError::from)?;
+        value_spent = value_spent.saturating_sub(received_coin_value)
     }
 
     // updated value spent is only allowed to increase or stay the same
@@ -84,8 +82,144 @@ fn get_value(
         return Ok(None);
     };
 
-    Ok(Some(coin.amount.multiply_ratio(
-        price_info.price.numerator(),
-        price_info.price.denominator(),
-    )))
+    let value = coin
+        .amount
+        .checked_mul_ceil(price_info.price)
+        .map_err(std_err_from_checked_mul_frac)?;
+
+    Ok(Some(value))
+}
+
+fn std_err_from_checked_mul_frac(e: cosmwasm_std::CheckedMultiplyFractionError) -> StdError {
+    match e {
+        cosmwasm_std::CheckedMultiplyFractionError::DivideByZero(e) => StdError::divide_by_zero(e),
+        cosmwasm_std::CheckedMultiplyFractionError::ConversionOverflow(e) => {
+            StdError::ConversionOverflow { source: e }
+        }
+        cosmwasm_std::CheckedMultiplyFractionError::Overflow(e) => StdError::overflow(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use crate::spend_limit::SpendLimitError;
+
+    use super::*;
+    use crate::price::PriceInfo;
+    use cosmwasm_std::testing::{MockApi, MockQuerier};
+    use cosmwasm_std::{testing::mock_dependencies, Uint64};
+    use cosmwasm_std::{Decimal, MemoryStorage, OwnedDeps};
+
+    use osmosis_std::types::osmosis::poolmanager::v1beta1::SwapAmountInRoute;
+    use rstest::fixture;
+    use rstest::rstest;
+
+    #[fixture]
+    fn price_resolution_config() -> PriceResolutionConfig {
+        PriceResolutionConfig {
+            quote_denom: "uusdc".to_string(),
+            staleness_threshold: Uint64::from(3_600_000_000u64),
+            twap_duration: Uint64::from(3_600_000_000u64),
+        }
+    }
+
+    #[fixture]
+    fn deps() -> OwnedDeps<MemoryStorage, MockApi, MockQuerier> {
+        mock_dependencies()
+    }
+
+    fn setup_price_infos<'a>(deps: DepsMut) {
+        let uosmo_price_info = PriceInfo {
+            price: Decimal::from_str("1.5").unwrap(),
+            last_updated_time: Timestamp::from_seconds(1_625_702_410),
+            swap_routes: vec![SwapAmountInRoute {
+                pool_id: 555,
+                token_out_denom: "uusdc".to_string(),
+            }],
+        };
+
+        PRICE_INFOS
+            .save(deps.storage, "uosmo", &uosmo_price_info)
+            .unwrap();
+    }
+
+    #[rstest]
+    #[case::no_spent_no_received(vec![], vec![], 0, 0, Ok(()))]
+    #[case::spent_only(vec![Coin::new(100, "uosmo")], vec![], 0, 150, Ok(()))]
+    #[case::received_only_no_decrese(vec![], vec![Coin::new(100, "uosmo")], 150, 150, Ok(()))]
+    #[case::received_only_no_decrese(vec![], vec![Coin::new(100, "uosmo"), Coin::new(100, "uusdc")], 150, 150, Ok(()))]
+    #[case::spent_and_received(vec![Coin::new(100, "uosmo")], vec![Coin::new(50, "uusdc")], 150, 250, Ok(()))]
+    #[case::untracked_coin(vec![Coin::new(100, "unknown")], vec![], 0, 0, Ok(()))]
+    #[case::untracked_coin(vec![Coin::new(100, "uusdc")], vec![Coin::new(100, "unknown")], 0, 100, Ok(()))]
+    #[case::exceed_spend_limit(vec![Coin::new(1_000_000, "uosmo")], vec![], 0, 1_500_000, Err(SpendLimitError::overspend(1_000_000, 1_500_000).into()))]
+    #[case::at_spend_limit(vec![Coin::new(1_000_000, "uusdc")], vec![], 0, 1_000_000, Ok(()))]
+    #[case::at_spend_limit(vec![Coin::new(1_000_000, "uosmo")], vec![Coin::new(500_000, "uusdc")], 0, 1_000_000, Ok(()))]
+    fn test_update_and_check_spend_limit(
+        mut deps: OwnedDeps<MemoryStorage, MockApi, MockQuerier>,
+        price_resolution_config: PriceResolutionConfig,
+        #[case] spent_coins: Vec<Coin>,
+        #[case] received_coins: Vec<Coin>,
+        #[case] initial_spending: u128,
+        #[case] expected_spending: u128,
+        #[case] expected_result: Result<(), ContractError>,
+    ) {
+        setup_price_infos(deps.as_mut());
+        let time = Timestamp::from_seconds(1_625_702_410); // Arbitrary fixed timestamp
+
+        let mut spending = Spending {
+            value_spent_in_period: Uint128::from(initial_spending),
+            last_spent_at: time.minus_seconds(5),
+        };
+
+        let limit = Uint128::from(1_000_000u128);
+
+        let result = update_and_check_spend_limit(
+            deps.as_mut(),
+            &mut spending,
+            spent_coins,
+            received_coins,
+            &price_resolution_config,
+            limit,
+            &Period::Day,
+            time,
+        );
+
+        assert_eq!(result, expected_result);
+
+        assert_eq!(
+            spending,
+            Spending {
+                value_spent_in_period: Uint128::from(expected_spending),
+                last_spent_at: time,
+            }
+        );
+    }
+
+    /// ensure that get value rounds up the multiplication result
+    /// This is important because if we can spend 0.x repeatedly,
+    /// it can be spent without limit as it rounds down to 0
+    #[test]
+    fn test_get_value_must_round_up() {
+        let mut deps = mock_dependencies();
+        setup_price_infos(deps.as_mut());
+
+        let conf = PriceResolutionConfig {
+            quote_denom: "uusdc".to_string(),
+            staleness_threshold: Uint64::from(3_600_000_000u64),
+            twap_duration: Uint64::from(3_600_000_000u64),
+        };
+
+        let time = Timestamp::from_seconds(1_625_702_410); // Arbitrary fixed timestamp
+
+        let coin = Coin::new(1, "uosmo");
+
+        let value = get_value(deps.as_mut(), &conf, time, coin)
+            .unwrap()
+            .unwrap()
+            .u128();
+
+        assert_eq!(value, 2);
+    }
 }

--- a/contracts/spend-limit/src/authenticator/common.rs
+++ b/contracts/spend-limit/src/authenticator/common.rs
@@ -44,10 +44,10 @@ pub fn try_spend_all(
             continue;
         };
 
-        spending
-            .unchecked_spend(coin.amount, price_info.price, reset_period, time)?
-            .ensure_within_limit(limit)?;
+        spending.unchecked_spend(coin.amount, price_info.price, reset_period, time)?;
     }
+
+    spending.ensure_within_limit(limit)?;
 
     Ok(())
 }

--- a/contracts/spend-limit/src/authenticator/common.rs
+++ b/contracts/spend-limit/src/authenticator/common.rs
@@ -8,25 +8,21 @@ use crate::{
     ContractError,
 };
 
-// Extract the fee being paid by the account. If the fee is paid via a grant, only count it if the granter is the same account
+/// Get the spending fee for an account. If the account is not the fee payer, it does not count towards the spending limit.
 pub fn get_account_spending_fee(
     account: &Addr,
     fee_payer: &Addr,
     fee_granter: Option<&Addr>,
     fee: Vec<Coin>,
 ) -> Vec<Coin> {
-    if let Some(fee_granter) = fee_granter {
-        if account == fee_granter {
-            fee
-        } else {
-            vec![]
-        }
+    // fee granter pay for the fee if specified
+    let fee_payer = fee_granter.unwrap_or(fee_payer);
+
+    // count fee paid towards this account only if the account is the fee payer
+    if account == fee_payer {
+        fee
     } else {
-        if account == fee_payer {
-            fee
-        } else {
-            vec![]
-        }
+        vec![]
     }
 }
 

--- a/contracts/spend-limit/src/authenticator/common.rs
+++ b/contracts/spend-limit/src/authenticator/common.rs
@@ -26,6 +26,7 @@ pub fn get_account_spending_fee(
     }
 }
 
+// TODO: calculate diff properly,
 pub fn try_spend_all(
     mut deps: DepsMut,
     spending: &mut Spending,
@@ -43,13 +44,9 @@ pub fn try_spend_all(
             continue;
         };
 
-        spending.try_spend(
-            coin.amount,
-            price_info.price,
-            limit.into(),
-            reset_period,
-            time,
-        )?;
+        spending
+            .unchecked_spend(coin.amount, price_info.price, reset_period, time)?
+            .ensure_within_limit(limit)?;
     }
 
     Ok(())

--- a/contracts/spend-limit/src/authenticator/composite.rs
+++ b/contracts/spend-limit/src/authenticator/composite.rs
@@ -1,16 +1,37 @@
 use std::str::FromStr;
 
-use serde::{Deserialize, Serialize};
+use cosmwasm_std::{from_json, StdError};
+use osmosis_std::types::osmosis::smartaccount::v1beta1::AccountAuthenticator;
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
-use super::AuthenticatorError;
+use crate::spend_limit::SpendLimitParams;
 
-#[derive(Serialize, Deserialize)]
-pub struct CosmwasmAuthenticatorData {
-    pub contract: String,
-    pub params: Vec<u8>,
+use thiserror::Error;
+
+#[derive(Error, Debug, PartialEq)]
+pub enum CompositeAuthenticatorError {
+    #[error("{0}")]
+    StdError(#[from] StdError),
+
+    #[error("Invalid composite id {composite_id}")]
+    InvalidCompositeId { composite_id: String },
 }
 
-#[derive(Serialize, Deserialize)]
+impl CompositeAuthenticatorError {
+    pub fn invalid_composite_id(composite_id: &str) -> Self {
+        Self::InvalidCompositeId {
+            composite_id: composite_id.to_string(),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug)]
+pub struct SpendLimitCosmwasmAuthenticatorData {
+    pub contract: String,
+    pub params: SpendLimitParams,
+}
+
+#[derive(Serialize, Deserialize, PartialEq, Debug, Clone)]
 pub struct SubAuthenticatorData {
     pub authenticator_type: String,
     pub data: Vec<u8>,
@@ -26,31 +47,53 @@ pub struct CompositeId {
 }
 
 impl FromStr for CompositeId {
-    type Err = AuthenticatorError;
+    type Err = CompositeAuthenticatorError;
 
     fn from_str(composite_id: &str) -> Result<Self, Self::Err> {
         let mut parts = composite_id.split('.').map(|s| s.parse::<u64>());
         let root = parts
             .next()
-            .ok_or_else(|| AuthenticatorError::invalid_composite_id(composite_id))?
-            .map_err(|_| AuthenticatorError::invalid_composite_id(composite_id))?;
+            .ok_or_else(|| CompositeAuthenticatorError::invalid_composite_id(composite_id))?
+            .map_err(|_| CompositeAuthenticatorError::invalid_composite_id(composite_id))?;
 
         let path = parts
             .collect::<Result<Vec<_>, _>>()
-            .map_err(|_| AuthenticatorError::invalid_composite_id(composite_id))?;
+            .map_err(|_| CompositeAuthenticatorError::invalid_composite_id(composite_id))?;
 
         Ok(CompositeId { root, path })
     }
 }
 
-// TODO:
-// - from composite id, get base id, query authenticator with that.
-// - from there, if it's a composite, parse data as []SubAuthenticatorData should pass
-// - if it's a cosmwasm, parse data as CosmwasmAuthenticatorData and pass (which is expected for spend limit case)
+pub trait CompositeAuthenticator {
+    fn child_authenticator_data<T>(self, path: &[u64]) -> Result<T, CompositeAuthenticatorError>
+    where
+        T: DeserializeOwned;
+}
+
+impl CompositeAuthenticator for AccountAuthenticator {
+    fn child_authenticator_data<T>(self, path: &[u64]) -> Result<T, CompositeAuthenticatorError>
+    where
+        T: DeserializeOwned,
+    {
+        let root_sub_auths: Vec<SubAuthenticatorData> = from_json(self.data)?;
+        let sub_auths = path
+            .iter()
+            .take(path.len() - 1)
+            .try_fold(root_sub_auths, |parent, &p| {
+                from_json(parent[usize::try_from(p).unwrap()].data.as_slice())
+            })?;
+
+        from_json(sub_auths[*path.last().unwrap() as usize].data.as_slice())
+            .map_err(CompositeAuthenticatorError::StdError)
+    }
+}
 
 #[cfg(test)]
 mod tests {
+    use crate::period::Period;
+
     use super::*;
+    use cosmwasm_std::to_json_vec;
     use rstest::rstest;
 
     #[rstest]
@@ -59,14 +102,99 @@ mod tests {
     #[case("1.2.3", Ok(CompositeId { root: 1, path: vec![2, 3] }))]
     #[case("904.2.3", Ok(CompositeId { root: 904, path: vec![2, 3] }))]
     #[case("54.666.2.1", Ok(CompositeId { root: 54, path: vec![666, 2, 1] }))]
-    #[case("1,2,3", Err(AuthenticatorError::invalid_composite_id(composite_id)))]
-    #[case("1.x.3", Err(AuthenticatorError::invalid_composite_id(composite_id)))]
-    #[case("abc", Err(AuthenticatorError::invalid_composite_id(composite_id)))]
+    #[case(
+        "1,2,3",
+        Err(CompositeAuthenticatorError::invalid_composite_id(composite_id))
+    )]
+    #[case(
+        "1.x.3",
+        Err(CompositeAuthenticatorError::invalid_composite_id(composite_id))
+    )]
+    #[case(
+        "abc",
+        Err(CompositeAuthenticatorError::invalid_composite_id(composite_id))
+    )]
     fn test_composite_id_from_str(
         #[case] composite_id: &str,
-        #[case] expected: Result<CompositeId, AuthenticatorError>,
+        #[case] expected: Result<CompositeId, CompositeAuthenticatorError>,
     ) {
         let result = CompositeId::from_str(composite_id);
         assert_eq!(result, expected);
+    }
+
+    #[test]
+    fn test_child_authenticator_data() {
+        let target_data = SpendLimitCosmwasmAuthenticatorData {
+            contract: "contract".to_string(),
+            params: SpendLimitParams {
+                limit: 1000000u128.into(),
+                reset_period: Period::Day,
+                time_limit: None,
+            },
+        };
+        let account_auth = AccountAuthenticator {
+            data: to_json_vec(&vec![
+                SubAuthenticatorData {
+                    authenticator_type: "Dummy".to_string(),
+                    data: vec![],
+                },
+                SubAuthenticatorData {
+                    authenticator_type: "CosmWasmAuthenticatorV1".to_string(),
+                    data: to_json_vec(&target_data).unwrap(),
+                },
+            ])
+            .unwrap(),
+            id: 1,
+            r#type: "AllOf".to_string(),
+        };
+
+        let result: Result<SpendLimitCosmwasmAuthenticatorData, CompositeAuthenticatorError> =
+            account_auth.child_authenticator_data(&[1]);
+        assert_eq!(result.unwrap(), target_data);
+
+        // more depth
+
+        let target_data = SpendLimitCosmwasmAuthenticatorData {
+            contract: "contract".to_string(),
+            params: SpendLimitParams {
+                limit: 1000000u128.into(),
+                reset_period: Period::Day,
+                time_limit: None,
+            },
+        };
+
+        let account_auth = AccountAuthenticator {
+            data: to_json_vec(&vec![
+                SubAuthenticatorData {
+                    authenticator_type: "AnyOf".to_string(),
+                    data: to_json_vec(&vec![
+                        SubAuthenticatorData {
+                            authenticator_type: "Dummy".to_string(),
+                            data: vec![],
+                        },
+                        SubAuthenticatorData {
+                            authenticator_type: "CosmWasmAuthenticatorV1".to_string(),
+                            data: to_json_vec(&target_data).unwrap(),
+                        },
+                    ])
+                    .unwrap(),
+                },
+                SubAuthenticatorData {
+                    authenticator_type: "Dummy".to_string(),
+                    data: vec![],
+                },
+                SubAuthenticatorData {
+                    authenticator_type: "Dummy".to_string(),
+                    data: vec![],
+                },
+            ])
+            .unwrap(),
+            id: 1,
+            r#type: "AllOf".to_string(),
+        };
+
+        let result: Result<SpendLimitCosmwasmAuthenticatorData, CompositeAuthenticatorError> =
+            account_auth.child_authenticator_data(&[0, 1]);
+        assert_eq!(result.unwrap(), target_data);
     }
 }

--- a/contracts/spend-limit/src/authenticator/composite.rs
+++ b/contracts/spend-limit/src/authenticator/composite.rs
@@ -1,0 +1,72 @@
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+
+use super::AuthenticatorError;
+
+#[derive(Serialize, Deserialize)]
+pub struct CosmwasmAuthenticatorData {
+    pub contract: String,
+    pub params: Vec<u8>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct SubAuthenticatorData {
+    pub authenticator_type: String,
+    pub data: Vec<u8>,
+}
+
+#[derive(PartialEq, Eq, Debug)]
+pub struct CompositeId {
+    /// Root authenticator id
+    pub root: u64,
+
+    /// Path to target authenticator
+    pub path: Vec<u64>,
+}
+
+impl FromStr for CompositeId {
+    type Err = AuthenticatorError;
+
+    fn from_str(composite_id: &str) -> Result<Self, Self::Err> {
+        let mut parts = composite_id.split('.').map(|s| s.parse::<u64>());
+        let root = parts
+            .next()
+            .ok_or_else(|| AuthenticatorError::invalid_composite_id(composite_id))?
+            .map_err(|_| AuthenticatorError::invalid_composite_id(composite_id))?;
+
+        let path = parts
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|_| AuthenticatorError::invalid_composite_id(composite_id))?;
+
+        Ok(CompositeId { root, path })
+    }
+}
+
+// TODO:
+// - from composite id, get base id, query authenticator with that.
+// - from there, if it's a composite, parse data as []SubAuthenticatorData should pass
+// - if it's a cosmwasm, parse data as CosmwasmAuthenticatorData and pass (which is expected for spend limit case)
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case("1", Ok(CompositeId { root: 1, path: vec![] }))]
+    #[case("1.2", Ok(CompositeId { root: 1, path: vec![2] }))]
+    #[case("1.2.3", Ok(CompositeId { root: 1, path: vec![2, 3] }))]
+    #[case("904.2.3", Ok(CompositeId { root: 904, path: vec![2, 3] }))]
+    #[case("54.666.2.1", Ok(CompositeId { root: 54, path: vec![666, 2, 1] }))]
+    #[case("1,2,3", Err(AuthenticatorError::invalid_composite_id(composite_id)))]
+    #[case("1.x.3", Err(AuthenticatorError::invalid_composite_id(composite_id)))]
+    #[case("abc", Err(AuthenticatorError::invalid_composite_id(composite_id)))]
+    fn test_composite_id_from_str(
+        #[case] composite_id: &str,
+        #[case] expected: Result<CompositeId, AuthenticatorError>,
+    ) {
+        let result = CompositeId::from_str(composite_id);
+        assert_eq!(result, expected);
+    }
+}

--- a/contracts/spend-limit/src/authenticator/error.rs
+++ b/contracts/spend-limit/src/authenticator/error.rs
@@ -1,10 +1,15 @@
 use cosmwasm_std::{Addr, StdError};
 use thiserror::Error;
 
+use super::composite::CompositeAuthenticatorError;
+
 #[derive(Error, Debug, PartialEq)]
 pub enum AuthenticatorError {
     #[error("{0}")]
     StdError(#[from] StdError),
+
+    #[error("{0}")]
+    CompositeAuthenticatorError(#[from] CompositeAuthenticatorError),
 
     #[error("Missing authenticator params")]
     MissingAuthenticatorParams,
@@ -20,9 +25,6 @@ pub enum AuthenticatorError {
         account: Addr,
         authenticator_id: String,
     },
-
-    #[error("Invalid composite id {composite_id}")]
-    InvalidCompositeId { composite_id: String },
 }
 
 impl AuthenticatorError {
@@ -34,12 +36,6 @@ impl AuthenticatorError {
         Self::AuthenticatorAlreadyExists {
             account,
             authenticator_id: authenticator_id.to_string(),
-        }
-    }
-
-    pub fn invalid_composite_id(composite_id: &str) -> Self {
-        Self::InvalidCompositeId {
-            composite_id: composite_id.to_string(),
         }
     }
 }

--- a/contracts/spend-limit/src/authenticator/error.rs
+++ b/contracts/spend-limit/src/authenticator/error.rs
@@ -20,6 +20,9 @@ pub enum AuthenticatorError {
         account: Addr,
         authenticator_id: String,
     },
+
+    #[error("Invalid composite id {composite_id}")]
+    InvalidCompositeId { composite_id: String },
 }
 
 impl AuthenticatorError {
@@ -31,6 +34,12 @@ impl AuthenticatorError {
         Self::AuthenticatorAlreadyExists {
             account,
             authenticator_id: authenticator_id.to_string(),
+        }
+    }
+
+    pub fn invalid_composite_id(composite_id: &str) -> Self {
+        Self::InvalidCompositeId {
+            composite_id: composite_id.to_string(),
         }
     }
 }

--- a/contracts/spend-limit/src/authenticator/handler/authenticate.rs
+++ b/contracts/spend-limit/src/authenticator/handler/authenticate.rs
@@ -65,6 +65,9 @@ pub fn authenticate(
     )?;
 
     // TODO: Better error that tells the fact that overspending comes from untracked spent fee
+    // - error spend limit is over from the previously failed transaction `UntrackedSpentFee`
+    // - error spend limit is over from the fee `CurrentFee`
+    // - else: `AfterTransaction`
 
     Ok(Response::new().add_attribute("action", "authenticate"))
 }
@@ -197,7 +200,7 @@ mod tests {
     #[case::fee_spent_to_the_limit("account", None, vec![Coin::new(666_666_666, "uosmo")], vec![], Ok(()))]
     #[case::fee_spent_to_the_limit_with_untracked_denoms("account", None,
         vec![Coin::new(333_333_333, "uosmo"), Coin::new(500_000_000, "untracked1")],
-        vec![Coin::new(500_000_001, "uusdc"), Coin::new(500_000_000, "untracked2")],
+        vec![Coin::new(500_000_000, "uusdc"), Coin::new(500_000_000, "untracked2")],
         Ok(()))
     ]
     #[case::fee_spent_over_the_limit("account", None,
@@ -216,13 +219,13 @@ mod tests {
         Err(SpendLimitError::overspend(1_000_000_000, 1_000_000_001).into()))
     ]
     #[case::fee_spent_over_the_limit("account", None,
-        vec![Coin::new(333_333_333, "uosmo"), Coin::new(500_000_002, "uusdc")],
+        vec![Coin::new(333_333_333, "uosmo"), Coin::new(500_000_001, "uusdc")],
         vec![],
         Err(SpendLimitError::overspend(1_000_000_000, 1_000_000_001).into()))
     ]
     #[case::fee_spent_over_the_limit("account", None,
         vec![Coin::new(333_333_333, "uosmo")],
-        vec![Coin::new(500_000_002, "uusdc")],
+        vec![Coin::new(500_000_001, "uusdc")],
         Err(SpendLimitError::overspend(1_000_000_000, 1_000_000_001).into()))
     ]
     #[case::fee_spent_over_the_limit_by_fee_grant("account", Some("granter"),

--- a/contracts/spend-limit/src/authenticator/handler/authenticate.rs
+++ b/contracts/spend-limit/src/authenticator/handler/authenticate.rs
@@ -63,6 +63,8 @@ pub fn authenticate(
         env.block.time,
     )?;
 
+    // TODO: Better error that tells the fact that overspending comes from untracked spent fee
+
     Ok(Response::new().add_attribute("action", "authenticate"))
 }
 
@@ -215,12 +217,12 @@ mod tests {
     #[case::fee_spent_over_the_limit("account", None,
         vec![Coin::new(333_333_333, "uosmo"), Coin::new(500_000_002, "uusdc")],
         vec![],
-        Err(SpendLimitError::overspend(500_000_001, 500_000_002).into()))
+        Err(SpendLimitError::overspend(1_000_000_000, 1_000_000_001).into()))
     ]
     #[case::fee_spent_over_the_limit("account", None,
         vec![Coin::new(333_333_333, "uosmo")],
         vec![Coin::new(500_000_002, "uusdc")],
-        Err(SpendLimitError::overspend(499_999_998, 499_999_999).into()))
+        Err(SpendLimitError::overspend(1_000_000_000, 1_000_000_001).into()))
     ]
     #[case::fee_spent_over_the_limit_by_fee_grant("account", Some("granter"),
         vec![Coin::new(1_000_000_001, "uusdc")],

--- a/contracts/spend-limit/src/authenticator/handler/authenticate.rs
+++ b/contracts/spend-limit/src/authenticator/handler/authenticate.rs
@@ -1,8 +1,8 @@
-use cosmwasm_std::{DepsMut, Env, Response, Timestamp};
+use cosmwasm_std::{Coins, DepsMut, Env, Response, Timestamp};
 use osmosis_authenticators::AuthenticationRequest;
 
 use crate::{
-    authenticator::common::{get_account_spending_fee, try_spend_all},
+    authenticator::common::{get_account_spending_fee, update_and_check_spend_limit},
     state::{PRICE_RESOLUTION_CONFIG, SPENDINGS, UNTRACKED_SPENT_FEES},
     ContractError,
 };
@@ -53,10 +53,11 @@ pub fn authenticate(
     // check whether the fee spent + about to spend is within the limit
     // this will not be committed to the state
     let coins = vec![untracked_spent_fee, account_spending_fee].concat();
-    try_spend_all(
+    update_and_check_spend_limit(
         deps,
         &mut spending,
         coins,
+        Coins::default(),
         &conf,
         params.limit,
         &params.reset_period,

--- a/contracts/spend-limit/src/authenticator/handler/confirm_execution.rs
+++ b/contracts/spend-limit/src/authenticator/handler/confirm_execution.rs
@@ -41,14 +41,14 @@ pub fn confirm_execution(
         .unwrap_or_default()
         .fee;
 
-    // add all untracked spent fees to the spent coins. 
-    // These are fees that have been deducted on previous failed tx, but still 
+    // add all untracked spent fees to the spent coins.
+    // These are fees that have been deducted on previous failed tx, but still
     // not counted on the spend limit. We add them here.
-    for coin in untracked_spent_fee {
-        spent_coins.add(coin)?;
+    for fee in untracked_spent_fee {
+        spent_coins.add(fee)?;
     }
 
-    // To avoid double counting, we subtract the account spending fee from the spent coins. 
+    // To avoid double counting, we subtract the account spending fee from the spent coins.
     // This is the fee for the current transaction and thus already captured by the difference in balances.
     let account_spending_fee =
         get_account_spending_fee(&account, &fee_payer, fee_granter.as_ref(), fee);

--- a/contracts/spend-limit/src/authenticator/handler/confirm_execution.rs
+++ b/contracts/spend-limit/src/authenticator/handler/confirm_execution.rs
@@ -52,9 +52,11 @@ pub fn confirm_execution(
     // This is the fee for the current transaction and thus already captured by the difference in balances.
     let account_spending_fee =
         get_account_spending_fee(&account, &fee_payer, fee_granter.as_ref(), fee);
-    for coin in account_spending_fee {
-        spent_coins.sub(coin)?;
+    for fee in account_spending_fee {
+        spent_coins.sub(fee)?;
     }
+
+    // TODO: calculate received coins
 
     let mut spending = SPENDINGS.load(deps.storage, spend_limit_key)?;
 

--- a/contracts/spend-limit/src/authenticator/handler/confirm_execution.rs
+++ b/contracts/spend-limit/src/authenticator/handler/confirm_execution.rs
@@ -33,7 +33,7 @@ pub fn confirm_execution(
 
     let pre_exec_balances = pre_exec_balances.try_into()?;
     let post_exec_balances = post_exec_balances.try_into()?;
-    let mut spent_coins = calculate_spent_coins(pre_exec_balances, post_exec_balances)?;
+    let mut spent_coins = calculate_spent_coins(&pre_exec_balances, &post_exec_balances)?;
 
     // Get recent untracked spent fee, the latest fee is already captured in the balance difference, so we need to subtract it
     let untracked_spent_fee = UNTRACKED_SPENT_FEES

--- a/contracts/spend-limit/src/authenticator/mod.rs
+++ b/contracts/spend-limit/src/authenticator/mod.rs
@@ -6,7 +6,11 @@ mod handler;
 use handler::*;
 
 pub use {
-    authenticate::authenticate, confirm_execution::confirm_execution, error::AuthenticatorError,
+    authenticate::authenticate,
+    composite::{CompositeAuthenticator, CompositeId, CosmwasmAuthenticatorData},
+    confirm_execution::confirm_execution,
+    error::AuthenticatorError,
     on_authenticator_added::on_authenticator_added,
-    on_authenticator_removed::on_authenticator_removed, track::track,
+    on_authenticator_removed::on_authenticator_removed,
+    track::track,
 };

--- a/contracts/spend-limit/src/authenticator/mod.rs
+++ b/contracts/spend-limit/src/authenticator/mod.rs
@@ -1,4 +1,5 @@
 mod common;
+mod composite;
 mod error;
 mod handler;
 

--- a/contracts/spend-limit/src/contract.rs
+++ b/contracts/spend-limit/src/contract.rs
@@ -4,7 +4,7 @@ use std::str::FromStr;
 use cosmwasm_std::entry_point;
 use cosmwasm_std::{
     ensure, from_json, to_json_binary, Addr, Binary, Deps, DepsMut, Env, MessageInfo, Order,
-    Response, StdResult, Timestamp,
+    Response, StdError, StdResult, Timestamp,
 };
 use cw2::set_contract_version;
 use osmosis_std::types::osmosis::smartaccount::v1beta1::SmartaccountQuerier;
@@ -120,7 +120,10 @@ pub fn query_spending(
 
     let spend_limit_auth_data = response
         .account_authenticator
-        .unwrap() // TODO: remove unwrap
+        .ok_or(StdError::not_found(&format!(
+            "Authenticator with account = {}, authenticator_id = {}",
+            account, authenticator_id
+        )))?
         .child_authenticator_data::<CosmwasmAuthenticatorData>(&composite_id.path)
         .map_err(AuthenticatorError::from)?;
 

--- a/contracts/spend-limit/src/integration.rs
+++ b/contracts/spend-limit/src/integration.rs
@@ -720,6 +720,7 @@ fn test_setup_and_teardown() {
     assert_eq!(spendings, vec![("2.1".to_string(), Spending::default())]);
 }
 
+// TODO: update this test and unignore
 #[test]
 #[ignore = "this test will require update again when introducing counting slippage & fee towards spending when swap"]
 fn test_1_click_trading() {

--- a/contracts/spend-limit/src/integration.rs
+++ b/contracts/spend-limit/src/integration.rs
@@ -7,10 +7,11 @@ use osmosis_std::types::cosmos::bank::v1beta1::QueryBalanceRequest;
 use osmosis_std::types::osmosis::poolmanager::v1beta1::{
     EstimateSwapExactAmountInRequest, EstimateSwapExactAmountInResponse,
 };
+use osmosis_std::types::osmosis::smartaccount;
 use osmosis_std::types::osmosis::{
-    authenticator::{self, MsgRemoveAuthenticator, MsgRemoveAuthenticatorResponse},
     gamm::v1beta1::MsgSwapExactAmountInResponse,
     poolmanager::v1beta1::{MsgSwapExactAmountIn, SwapAmountInRoute},
+    smartaccount::v1beta1::{MsgRemoveAuthenticator, MsgRemoveAuthenticatorResponse},
 };
 use osmosis_test_tube::{
     cosmrs::proto::tendermint::v0_37::abci::ResponseDeliverTx,
@@ -1240,10 +1241,11 @@ fn one_click_swap_exact_amount_in(
 const MAXIMUM_UNAUTHENTICATED_GAS: u64 = 120_000;
 fn set_maximum_unauthenticated_gas(app: &OsmosisTestApp, maximum_unauthenticated_gas: u64) {
     app.set_param_set(
-        "authenticator",
-        authenticator::Params {
+        "smartaccount",
+        smartaccount::v1beta1::Params {
             maximum_unauthenticated_gas,
-            are_smart_accounts_active: true,
+            is_smart_account_active: true,
+            circuit_breaker_controllers: vec![],
         }
         .to_any(),
     )

--- a/contracts/spend-limit/src/integration.rs
+++ b/contracts/spend-limit/src/integration.rs
@@ -943,6 +943,7 @@ fn test_1_click_trading() {
             &QueryMsg::Spending {
                 account: account_owner.address(),
                 authenticator_id: format!("{one_click_trading_auth_id_1}.1"),
+                reset_period: Period::Day,
             },
         )
         .unwrap();
@@ -1059,6 +1060,7 @@ fn test_1_click_trading() {
             &QueryMsg::Spending {
                 account: account_owner.address(),
                 authenticator_id: format!("{one_click_trading_auth_id_2}.1"),
+                reset_period: Period::Day,
             },
         )
         .unwrap();
@@ -1075,6 +1077,7 @@ fn test_1_click_trading() {
             &QueryMsg::Spending {
                 account: account_owner.address(),
                 authenticator_id: format!("{one_click_trading_auth_id_1}.1"),
+                reset_period: Period::Day,
             },
         )
         .unwrap();
@@ -1084,18 +1087,18 @@ fn test_1_click_trading() {
     // increases time for 2 days
     app.increase_time(24 * 60 * 60 * 2);
 
-    // // TODO: make this test pass: query spending for session 1
-    // // let SpendingResponse { spending } = wasm
-    // //     .query(
-    // //         &contract_addr,
-    // //         &QueryMsg::Spending {
-    // //             account: account_owner.address(),
-    // //             authenticator_id: format!("{one_click_trading_auth_id_1}.1"),
-    // //         },
-    // //     )
-    // //     .unwrap();
+    let SpendingResponse { spending } = wasm
+        .query(
+            &contract_addr,
+            &QueryMsg::Spending {
+                account: account_owner.address(),
+                authenticator_id: format!("{one_click_trading_auth_id_1}.1"),
+                reset_period: Period::Day,
+            },
+        )
+        .unwrap();
 
-    // // assert_eq!(spending.value_spent_in_period.u128(), 0);
+    assert_eq!(spending.value_spent_in_period.u128(), 0);
 
     // spend to the limit
     let uusdc_in: u128 = 10;
@@ -1146,6 +1149,7 @@ fn test_1_click_trading() {
             &QueryMsg::Spending {
                 account: account_owner.address(),
                 authenticator_id: format!("{one_click_trading_auth_id_1}.1"),
+                reset_period: Period::Day,
             },
         )
         .unwrap();

--- a/contracts/spend-limit/src/integration.rs
+++ b/contracts/spend-limit/src/integration.rs
@@ -3,7 +3,6 @@
 #![cfg(all(test, not(tarpaulin)))]
 
 use cosmwasm_std::{Coin, Timestamp, Uint128};
-use osmosis_std::types::cosmos::bank::v1beta1::QueryBalanceRequest;
 use osmosis_std::types::osmosis::poolmanager::v1beta1::{
     EstimateSwapExactAmountInRequest, EstimateSwapExactAmountInResponse,
 };
@@ -13,6 +12,7 @@ use osmosis_std::types::osmosis::{
     poolmanager::v1beta1::{MsgSwapExactAmountIn, SwapAmountInRoute},
     smartaccount::v1beta1::{MsgRemoveAuthenticator, MsgRemoveAuthenticatorResponse},
 };
+use osmosis_test_tube::osmosis_std::types::cosmos::bank::v1beta1::QueryBalanceRequest;
 use osmosis_test_tube::{
     cosmrs::proto::tendermint::v0_37::abci::ResponseDeliverTx,
     osmosis_std::types::cosmos::bank::v1beta1::MsgSend, Account, Bank, FeeSetting, Gamm, Module,
@@ -944,7 +944,6 @@ fn test_1_click_trading() {
             &QueryMsg::Spending {
                 account: account_owner.address(),
                 authenticator_id: format!("{one_click_trading_auth_id_1}.1"),
-                reset_period: Period::Day,
             },
         )
         .unwrap();
@@ -1061,7 +1060,6 @@ fn test_1_click_trading() {
             &QueryMsg::Spending {
                 account: account_owner.address(),
                 authenticator_id: format!("{one_click_trading_auth_id_2}.1"),
-                reset_period: Period::Day,
             },
         )
         .unwrap();
@@ -1078,7 +1076,6 @@ fn test_1_click_trading() {
             &QueryMsg::Spending {
                 account: account_owner.address(),
                 authenticator_id: format!("{one_click_trading_auth_id_1}.1"),
-                reset_period: Period::Day,
             },
         )
         .unwrap();
@@ -1094,7 +1091,6 @@ fn test_1_click_trading() {
             &QueryMsg::Spending {
                 account: account_owner.address(),
                 authenticator_id: format!("{one_click_trading_auth_id_1}.1"),
-                reset_period: Period::Day,
             },
         )
         .unwrap();
@@ -1150,7 +1146,6 @@ fn test_1_click_trading() {
             &QueryMsg::Spending {
                 account: account_owner.address(),
                 authenticator_id: format!("{one_click_trading_auth_id_1}.1"),
-                reset_period: Period::Day,
             },
         )
         .unwrap();

--- a/contracts/spend-limit/src/msg.rs
+++ b/contracts/spend-limit/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 pub use osmosis_std::types::osmosis::poolmanager::v1beta1::SwapAmountInRoute;
 
-use crate::{period::Period, price::PriceResolutionConfig, spend_limit::Spending};
+use crate::{price::PriceResolutionConfig, spend_limit::Spending};
 
 // re-export the structs from osmosis_authenticators
 pub use osmosis_authenticators::AuthenticatorSudoMsg as SudoMsg;
@@ -25,7 +25,6 @@ pub enum QueryMsg {
     Spending {
         account: String,
         authenticator_id: String,
-        reset_period: Period,
     },
 
     #[returns(SpendingsByAccountResponse)]

--- a/contracts/spend-limit/src/msg.rs
+++ b/contracts/spend-limit/src/msg.rs
@@ -1,7 +1,7 @@
 use cosmwasm_schema::{cw_serde, QueryResponses};
 pub use osmosis_std::types::osmosis::poolmanager::v1beta1::SwapAmountInRoute;
 
-use crate::{price::PriceResolutionConfig, spend_limit::Spending};
+use crate::{period::Period, price::PriceResolutionConfig, spend_limit::Spending};
 
 // re-export the structs from osmosis_authenticators
 pub use osmosis_authenticators::AuthenticatorSudoMsg as SudoMsg;
@@ -25,6 +25,7 @@ pub enum QueryMsg {
     Spending {
         account: String,
         authenticator_id: String,
+        reset_period: Period,
     },
 
     #[returns(SpendingsByAccountResponse)]

--- a/contracts/spend-limit/src/spend_limit/error.rs
+++ b/contracts/spend-limit/src/spend_limit/error.rs
@@ -20,18 +20,15 @@ pub enum SpendLimitError {
     #[error("Accumulating spent value error: {0}")]
     AccumulatingSpentValueError(#[from] OverflowError),
 
-    #[error("Overspend: remaining quota {remaining}, requested {requested}")]
-    Overspend {
-        remaining: Uint128,
-        requested: Uint128,
-    },
+    #[error("Overspend: {spent} has been spent but limit is {limit}")]
+    Overspend { limit: Uint128, spent: Uint128 },
 }
 
 impl SpendLimitError {
-    pub fn overspend(remaining: u128, requested: u128) -> Self {
+    pub fn overspend(limit: u128, spent: u128) -> Self {
         Self::Overspend {
-            remaining: Uint128::from(remaining),
-            requested: Uint128::from(requested),
+            limit: Uint128::from(limit),
+            spent: Uint128::from(spent),
         }
     }
 }

--- a/contracts/spend-limit/src/spend_limit/mod.rs
+++ b/contracts/spend-limit/src/spend_limit/mod.rs
@@ -5,7 +5,7 @@ use cosmwasm_std::Coin;
 
 pub use error::SpendLimitError;
 pub use params::{SpendLimitParams, TimeLimit};
-pub use spending::{calculate_spent_coins, Spending};
+pub use spending::{calculate_received_coins, calculate_spent_coins, Spending};
 
 use cosmwasm_std::Addr;
 use cw_storage_plus::Map;

--- a/contracts/spend-limit/src/spend_limit/spending.rs
+++ b/contracts/spend-limit/src/spend_limit/spending.rs
@@ -48,6 +48,17 @@ impl Spending {
         Ok(self)
     }
 
+    pub fn update(
+        &mut self,
+        value_spent_in_period: Uint128,
+        last_spent_at: Timestamp,
+    ) -> &mut Self {
+        self.value_spent_in_period = value_spent_in_period;
+        self.last_spent_at = last_spent_at;
+
+        self
+    }
+
     /// ensure that the value spent in the period is not over the limit
     pub fn ensure_within_limit(&self, limit: Uint128) -> SpendLimitResult<()> {
         if self.value_spent_in_period > limit {
@@ -62,7 +73,7 @@ impl Spending {
 
     /// Get the value spent in the period.
     /// If the period has changed, the value spent in the period is reset to zero.
-    fn get_or_reset_value_spent(
+    pub fn get_or_reset_value_spent(
         &self,
         period: &Period,
         at: Timestamp,

--- a/contracts/spend-limit/src/test_helper/authenticator_setup.rs
+++ b/contracts/spend-limit/src/test_helper/authenticator_setup.rs
@@ -5,7 +5,7 @@
 use std::path::PathBuf;
 
 use cosmwasm_std::to_json_binary;
-use osmosis_std::types::osmosis::authenticator::{
+use osmosis_std::types::osmosis::smartaccount::v1beta1::{
     MsgAddAuthenticator, MsgAddAuthenticatorResponse,
 };
 use osmosis_test_tube::{Account, OsmosisTestApp, Runner, SigningAccount, Wasm};
@@ -188,7 +188,7 @@ where
         e.ty == "message"
             && e.attributes
                 .iter()
-                .any(|a| a.key == "module" && a.value == "authenticator")
+                .any(|a| a.key == "module" && a.value == "smartaccount")
     })
     .unwrap()
     .attributes

--- a/contracts/spend-limit/src/test_helper/mock_stargate_querier.rs
+++ b/contracts/spend-limit/src/test_helper/mock_stargate_querier.rs
@@ -31,6 +31,10 @@ impl<C: DeserializeOwned> MockStargateQuerier<C> {
         self.stargate_query_handler = Some(handler);
         self
     }
+
+    pub fn update_balance(&mut self, addr: impl Into<String>, balance: Vec<Coin>) {
+        self.mock_querier.update_balance(addr, balance);
+    }
 }
 
 impl<C: CustomQuery + DeserializeOwned> Querier for MockStargateQuerier<C> {


### PR DESCRIPTION
Previously, in a single tx, only reducing balance is taken into account as spending, but with that, when swapping, it count all token in, if tracked, as spending.

This PR changes that so that:
- If balance has increased after tx and it's a tracked token, subtract that amount from spending
- If after subtracted, the spending is lower than previous spending, spending stays the same


It also includes some other fixes, namely:
- [round up value conversion](https://github.com/osmosis-labs/spend-limit-authenticator/pull/5/files#diff-d8147bc594fcda43b6619b063f123219eab17a4afec4340d0ba4c2746780e746R74-R91) to avoid cases where attacker tries to spend something with value in quoted denom <1 repeatedly and bypass spend limit
- [reset value spent if period changed in query](https://github.com/osmosis-labs/spend-limit-authenticator/pull/5/files#diff-692571c552ffbe61d18cd35c661a531428549912116d0a2da7746ac9fac2b583R113-R118) - this requires further update, querying authenticator params to get period should be better, but will leave that for another PR.